### PR TITLE
Update Cirrus to v0.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This library is a type declaration of CSS class names in [cirrus-ui](https://git
 ## Install
 
 ```bash
-npm install @alker0/cirrus-types
+npm install -D @alker0/cirrus-types
 ```
 
 ## Usage

--- a/cdn/cirrus.css
+++ b/cdn/cirrus.css
@@ -1,1 +1,1 @@
-@import 'https://cdn.jsdelivr.net/npm/cirrus-ui@0.6.1/dist/cirrus.min.css';
+@import 'https://cdn.jsdelivr.net/npm/cirrus-ui@0.6.2/dist/cirrus.min.css';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@alker0/cirrus-types",
   "description": "A type declaration for cirrus.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": "Fujita Hitoshi",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "postcss-ts-classnames": "^0.3.0"
   },
   "peerDependencies": {
-    "cirrus-ui": "0.6.1"
+    "cirrus-ui": "0.6.2"
   },
   "peerDependenciesMeta": {
     "cirrus-ui": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,22 @@
     "type": "git",
     "url": "https://github.com/alker0/cirrus-types"
   },
+  "keywords": [
+    "css",
+    "cirrus",
+    "classes",
+    "classname",
+    "definition",
+    "style",
+    "styles",
+    "ts",
+    "type",
+    "typed",
+    "types",
+    "typing",
+    "typescript",
+    "ui"
+  ],
   "main": "",
   "types": "dist/cirrus.d.ts",
   "files": [


### PR DESCRIPTION
This PR:
- Adds `-D` option into `npm install` example
- Updates Cirrus to 0.6.2